### PR TITLE
Enable travis via tox in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: required
+
+language: python
+
+python:
+  - "2.7"
+
+services:
+  - docker
+
+before_install:
+  - sudo apt-get install -y openssl
+  - pip install "zeroc-ice>3.6.4,<3.7"
+  - python -c "import Ice; print Ice.stringVersion()"
+
+script:
+  - python setup.py sdist
+  - pip install dist/omero-dropbox*gz
+  - docker build -t test .
+
+deploy:
+  provider: pypi
+  user: $PYPI_USER
+  password: $PYPI_PASSWORD
+  on:
+    tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ COPY README.rst /src
 COPY src /src/src
 WORKDIR /src
 
-RUN rst-lint README.rst
-RUN python setup.py sdist
+RUN /v/bin/rst-lint README.rst
+RUN /v/bin/python setup.py sdist
 RUN /v/bin/pip install dist/omero-py*gz
 RUN /v/bin/python -c "import omero_version; print omero_version.omero_version"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:centos7
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+RUN yum install -y python-setuptools python-virtualenv git python-yaml
+RUN virtualenv /v && /v/bin/pip install twine tox pytest pytest-xdist restructuredtext-lint
+RUN /v/bin/pip install --upgrade pip setuptools
+RUN /v/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
+
+# Optimize for fixing tests
+COPY *.py /src/
+COPY README.rst /src
+COPY src /src/src
+WORKDIR /src
+
+RUN rst-lint README.rst
+RUN python setup.py sdist
+RUN /v/bin/pip install dist/omero-py*gz
+RUN /v/bin/python -c "import omero_version; print omero_version.omero_version"
+
+# Copy test-related files and run
+COPY ice.config /src/
+COPY *.ini /src/
+COPY test /src/test
+RUN /v/bin/tox

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,9 @@ WORKDIR /src
 
 RUN /v/bin/rst-lint README.rst
 RUN /v/bin/python setup.py sdist
-RUN /v/bin/pip install dist/omero-py*gz
-RUN /v/bin/python -c "import omero_version; print omero_version.omero_version"
+RUN /v/bin/pip install dist/omero-dropbox*gz
 
 # Copy test-related files and run
-COPY ice.config /src/
-COPY *.ini /src/
 COPY test /src/test
+COPY *.ini /src/
 RUN /v/bin/tox

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ Copyright
 
 2009-2019, The Open Microscopy Environment, Glencoe Software, Inc.
 
-.. _OMERO.py: https://openmicroscopy.org/
+.. _OMERO: https://www.openmicroscopy.org/omero
+.. _OMERO.py: https://pypi.python.org/pypi/omero-py
 .. _ZeroC IcePy: https://zeroc.com/
 .. _Running and writing tests: https://docs.openmicroscopy.org/latest/omero/developers/testing.html

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name="omero-dropbox",
       author="The Open Microscopy Team",
       author_email="ome-devel@lists.openmicroscopy.org.uk",
       url=url,
-      package_dir={"": "target"},
+      package_dir={"": "src"},
       packages=[''],
       install_requires=[
           "omero-py",  # requires Ice (use wheel for faster installs)

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ setenv =
     PYTHONPATH = {toxinidir}/target
 commands =
     python setup.py install
-    pytest {posargs:-n8 -m "not broken" -rf test/unit/clitest/ test/unit/fstest/ test/unit/gatewaytest/ test/unit/scriptstest/}
+    pytest {posargs:-n8 -m "not broken" -rf test}

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pytest-sugar
     pytest-xdist
 setenv =
-    PYTHONPATH = {toxinidir}/target
+    PYTHONPATH = {toxinidir}/src
 commands =
     python setup.py install
     pytest {posargs:-n8 -m "not broken" -rf test}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps =
+    numpy
+    pytest
+    https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
+    pytest-sugar
+    pytest-xdist
+setenv =
+    PYTHONPATH = {toxinidir}/target
+commands =
+    python setup.py install
+    pytest {posargs:-n8 -m "not broken" -rf test/unit/clitest/ test/unit/fstest/ test/unit/gatewaytest/ test/unit/scriptstest/}


### PR DESCRIPTION
Following the strategy in the recent omero-py and omero-web PRs.