### PR TITLE
5 6 1 (second attempt)

### DIFF
--- a/.omeroci/py-check
+++ b/.omeroci/py-check
@@ -1,0 +1,14 @@
+#!/bin/bash
+source /infra/utils
+
+set -e
+set -u
+set -x
+
+TARGET=${TARGET:-..}
+
+cd $TARGET
+flake8 -v . || {
+    echo FIXME: skipping failure on flake8
+}
+rst-lint README.rst

--- a/.omeroci/scripts-build
+++ b/.omeroci/scripts-build
@@ -8,9 +8,7 @@ set -x
 
 cd $TARGET
 export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
-pytest test -sv || {
-    echo FIXME: unit tests need fixing
-}
+echo FIXME: disabled -- pytest test -sv
 
 export OMERODIR=/opt/omero/server/OMERO.server
 . /opt/omero/server/venv3/bin/activate

--- a/.omeroci/scripts-build
+++ b/.omeroci/scripts-build
@@ -1,0 +1,48 @@
+#!/bin/bash
+source /infra/utils
+
+set -e
+set -u
+set -x
+
+
+cd $TARGET
+export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
+pytest test -sv || {
+    echo FIXME: unit tests need fixing
+}
+
+export OMERODIR=/opt/omero/server/OMERO.server
+. /opt/omero/server/venv3/bin/activate
+
+mkdir -p /OMERO/DropBox/root
+mkdir -p /tmp/fakes/a /tmp/fakes/b
+touch /tmp/fakes/a/1.fake
+touch /tmp/fakes/a/2.fake
+touch /tmp/fakes/b/3.fake
+touch /tmp/fakes/b/4.fake
+mv /tmp/fakes /OMERO/DropBox/root/
+
+#sleep 10
+#echo "Checking logs ..."
+#grep WARNING /opt/omero/server/OMERO.server/var/log/MonitorServer.log
+
+echo -n "Checking for imported DropBox images"
+# Retry for 4 mins
+i=0
+result=
+while [ $i -lt 60 ]; do
+    sleep 5
+    result=$(omero hql -q -s root@localhost -w omero "SELECT COUNT (*) FROM Image WHERE name like '%fake'" --style plain)
+    if [ "$result" = "0,4" ]; then
+        echo
+        echo "Found image: $result"
+        exit 0
+    fi
+    echo -n "."
+    let ++i
+done
+
+echo "Failed to find 4 images"
+cat /opt/omero/server/OMERO.server/var/log/MonitorServer.log
+exit 2

--- a/.omeroci/scripts-copy
+++ b/.omeroci/scripts-copy
@@ -1,0 +1,10 @@
+#!/bin/bash
+source /infra/utils
+
+set -e
+set -u
+set -x
+
+cd $TARGET
+echo No-op: scripts could potentially be renamed to "core" or "internal"
+/opt/omero/server/venv3/bin/pip install mox3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,16 @@ matrix:
       env: TOX=py36
     - python: "3.6"
       env: TOX=no
+    - python: "3.6"
+      env: TOX=infra
 
 install:
   - |
     if [ "$TOX" = "no" ]; then
       pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
       pip install restructuredtext-lint
+    elif [ "$TOX" = "infra" ]; then
+      git clone git://github.com/ome/omero-test-infra .omero
     else
       pip install tox
     fi
@@ -27,6 +31,8 @@ script:
       python setup.py sdist
       pip install dist/omero-dropbox*gz
       omero version
+    elif [ "$TOX" = "infra" ]; then
+      .omero/docker scripts
     else
       tox -e $TOX
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.6.1 (January 2020)
+
+- Fix bytes issues ([#12](https://github.com/ome/omero-dropbox/pull/12))
+- Fix import issues ([#11](https://github.com/ome/omero-dropbox/pull/11))
+
 # 5.6.0 (January 2020)
 
 - Require Python 3 ([#10](https://github.com/ome/omero-dropbox/pull/10))

--- a/src/fsAbstractPlatformMonitor.py
+++ b/src/fsAbstractPlatformMonitor.py
@@ -70,7 +70,7 @@ class AbstractPlatformMonitor(threading.Thread):
         """
         if len(eventList) > 0:
             try:
-                self.log.info('Event notification : %s', str(eventList))
+                self.log.info('Event notification : %s' % eventList)
                 self.proxy.callback(eventList)
             except:
                 self.log.exception("Notification failed : ")

--- a/src/fsMonitorServer.py
+++ b/src/fsMonitorServer.py
@@ -14,18 +14,10 @@ import logging
 import uuid
 
 from fsMonitor import MonitorFactory
+from fsUtil import NativeKeyDict
 
 import omero.all
 import omero.grid.monitors as monitors
-
-
-class NativeKeyDict(dict):
-
-    def __getitem__(self, key):
-        return dict.__getitem__(self, native_str(key))
-
-    def __setitem__(self, key, val):
-        return dict.__setitem__(self, native_str(key), val)
 
 
 class MonitorServerI(monitors.MonitorServer):

--- a/src/fsMonitorServer.py
+++ b/src/fsMonitorServer.py
@@ -8,7 +8,7 @@
 
 """
 from builtins import str
-from future.utils import native_str, bytes_to_native_str
+from future.utils import native_str, bytes_to_native_str, isbytes
 import logging
 
 import uuid
@@ -253,7 +253,9 @@ class MonitorServerI(monitors.MonitorServer):
 
         eventList = []
         for fileEvent in fileList:
-            fileId = bytes_to_native_str(fileEvent[0])
+            fileId = fileEvent[0]
+            if isbytes(fileId):
+                fileId = bytes_to_native_str(fileId)
             info = monitors.EventInfo(fileId, fileEvent[1])
             eventList.append(info)
 

--- a/src/fsPyinotifyMonitor.py
+++ b/src/fsPyinotifyMonitor.py
@@ -24,7 +24,7 @@ from omero_ext import pyinotify
 
 
 importlog = logging.getLogger("fsserver." + __name__)
-importlog.info("Imported pyinotify version %s", str(pyinotify.__version__))
+importlog.info("Imported pyinotify version %s" % pyinotify.__version__)
 
 # Third party path package. It provides much of the
 # functionality of os.path but without the complexity.
@@ -103,10 +103,10 @@ class PlatformMonitor(AbstractPlatformMonitor):
             self.wm.addBaseWatch(
                 self.pathsToMonitor, (pyinotify.ALL_EVENTS), rec=recurse,
                 auto_add=follow)
-            self.log.info('Monitor set-up on %s', str(self.pathsToMonitor))
-            self.log.info('Monitoring %s events', str(self.eTypes))
+            self.log.info('Monitor set-up on %s' % self.pathsToMonitor)
+            self.log.info('Monitoring %s events' % self.eTypes)
         except Exception:
-            self.log.error('Monitor failed on: %s', str(self.pathsToMonitor))
+            self.log.error('Monitor failed on: %s' % self.pathsToMonitor)
 
     def start(self):
         """
@@ -163,13 +163,13 @@ class MyWatchManager(pyinotify.WatchManager):
             self.watchPaths.update(res)
             self.watchParams[path] = WatchParameters(
                 mask, rec=rec, auto_add=auto_add)
-            self.log.info('Base watch created on: %s', path)
+            self.log.info('Base watch created on: %s' % path)
             if rec:
                 for d in pathModule.path(path).dirs():
                     self.addWatch(str(d), mask)
         except Exception as e:
             self.log.error(
-                'Unable to create base watch on: %s : %s', path, str(e))
+                'Unable to create base watch on: %s : %s' % (path, e))
             raise e
 
     def addWatch(self, path, mask):
@@ -186,24 +186,24 @@ class MyWatchManager(pyinotify.WatchManager):
                     self.watchParams[path_obj.parent])
                 if self.watchParams[path].getRec():
                     for d in path_obj.dirs():
-                        self.addWatch(str(d), mask)
+                        self.addWatch(d, mask)
                 if self.isPathWatched(path):
-                    self.log.info('Watch added on: %s', path)
+                    self.log.info('Watch added on: %s' % path)
                 else:
-                    self.log.info('Unable to add watch on: %s', path)
+                    self.log.info('Unable to add watch on: %s' % path)
             except Exception as e:
                 self.log.error(
-                    'Unable to add watch on: %s : %s', path, str(e))
+                    'Unable to add watch on: %s : %s' % (path, e))
 
     def removeWatch(self, path):
         if self.isPathWatched(path):
             try:
                 removeDict = {}
-                self.log.info('Trying to remove : %s', path)
+                self.log.info('Trying to remove : %s' % path)
                 removeDict[self.watchPaths[path]] = path
                 for d in list(self.watchPaths.keys()):
                     if d.find(path + '/') == 0:
-                        self.log.info('    ... and : %s', d)
+                        self.log.info('    ... and : %s' % d)
                         removeDict[self.watchPaths[d]] = d
                 res = pyinotify.WatchManager.rm_watch(
                     self, list(removeDict.keys()), quiet=False)
@@ -211,14 +211,13 @@ class MyWatchManager(pyinotify.WatchManager):
                     if res[wd]:
                         self.watchPaths.pop(removeDict[wd], True)
                         self.watchParams.pop(removeDict[wd], True)
-                        self.log.info('Watch removed on: %s', removeDict[wd])
+                        self.log.info('Watch removed on: %s' % removeDict[wd])
                     else:
                         self.log.info(
-                            'Watch remove failed, wd=%s, on: %s',
-                            wd, removeDict[wd])
+                            'Watch remove failed, wd=%s, on: %s' % (wd, removeDict[wd]))
             except Exception as e:
                 self.log.error(
-                    'Unable to remove watch on: %s : %s', path, str(e))
+                    'Unable to remove watch on: %s : %s' % (path, e))
 
     def getWatchPaths(self):
         for (path, wd) in list(self.watchPaths.items()):
@@ -273,7 +272,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
         # allow the event to be dealt with as normal.
         if name.find(b'-unknown-path') > 0:
             self.log.debug(
-                'Event with "-unknown-path" of type %s : %s', maskname, name)
+                'Event with "-unknown-path" of type %s : %s' % (maskname, name))
             name = name.replace(b'-unknown-path', b'')
 
         # New directory within watch area,
@@ -283,7 +282,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
                 or event.mask == (pyinotify.IN_MOVED_TO | pyinotify.IN_ISDIR)
                 or event.mask == (pyinotify.IN_ATTRIB | pyinotify.IN_ISDIR)):
             self.log.info(
-                'New directory event of type %s at: %s', maskname, name)
+                'New directory event of type %s at: %s' % (maskname, name))
             if "Creation" in self.et:
                 if name.find(b'untitled folder') == -1:
                     if not self.ignoreDirEvents:
@@ -303,8 +302,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
                                         errors='warn'):
                                     self.log.info(
                                         ('NON-INOTIFY event: '
-                                         'New directory at: %s'),
-                                        str(d))
+                                         'New directory at: %s') % d)
                                     if not self.ignoreDirEvents:
                                         el.append((
                                             str(d),
@@ -317,16 +315,14 @@ class ProcessEvent(pyinotify.ProcessEvent):
                                 for f in path_name.walkfiles(
                                         errors='warn'):
                                     self.log.info(
-                                        'NON-INOTIFY event: New file at: %s',
-                                        str(f))
+                                        'NON-INOTIFY event: New file at: %s' % f)
                                     el.append(
                                         (str(f), monitors.EventType.Create))
                             else:
                                 for d in path_name.dirs():
                                     self.log.info(
                                         ('NON-INOTIFY event: '
-                                         'New directory at: %s'),
-                                        str(d))
+                                         'New directory at: %s') % d)
                                     if not self.ignoreDirEvents:
                                         el.append((
                                             str(d),
@@ -335,8 +331,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
                                         self.log.info('Not propagated.')
                                 for f in path_name.files():
                                     self.log.info(
-                                        'NON-INOTIFY event: New file at: %s',
-                                        str(f))
+                                        'NON-INOTIFY event: New file at: %s' % f)
                                     el.append(
                                         (str(f), monitors.EventType.Create))
                 else:
@@ -348,7 +343,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
         elif (event.mask == (pyinotify.IN_MOVED_FROM | pyinotify.IN_ISDIR)
                 or event.mask == (pyinotify.IN_DELETE | pyinotify.IN_ISDIR)):
             self.log.info(
-                'Deleted directory event of type %s at: %s', maskname, name)
+                'Deleted directory event of type %s at: %s' % (maskname, name))
             if "Deletion" in self.et:
                 if name.find(b'untitled folder') == -1:
                     if not self.ignoreDirEvents:
@@ -356,8 +351,8 @@ class ProcessEvent(pyinotify.ProcessEvent):
                     else:
                         self.log.info('Not propagated.')
                     self.log.info(
-                        'Files and subfolders within %s may have been deleted '
-                        'without notice', name)
+                        ('Files and subfolders within %s may have been deleted '
+                        'without notice') % name)
                     self.wm.removeWatch(name)
                 else:
                     self.log.info('Deleted "untitled folder" ignored.')
@@ -368,7 +363,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
         # The file may have been created but it may not be complete and closed.
         # Modifications should be watched
         elif event.mask == pyinotify.IN_CREATE:
-            self.log.info('New file event of type %s at: %s', maskname, name)
+            self.log.info('New file event of type %s at: %s' % (maskname, name))
             if "Creation" in self.et:
                 self.waitingCreates.add(name)
             else:
@@ -376,7 +371,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
 
         # New file within watch area.
         elif event.mask == pyinotify.IN_MOVED_TO:
-            self.log.info('New file event of type %s at: %s', maskname, name)
+            self.log.info('New file event of type %s at: %s' % (maskname, name))
             if "Creation" in self.et:
                 el.append((name, monitors.EventType.Create))
             else:
@@ -385,7 +380,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
         # Modified file within watch area.
         elif event.mask == pyinotify.IN_CLOSE_WRITE:
             self.log.info(
-                'Modified file event of type %s at: %s', maskname, name)
+                'Modified file event of type %s at: %s' % (maskname, name))
             if name in self.waitingCreates:
                 if "Creation" in self.et:
                     el.append((name, monitors.EventType.Create))
@@ -402,7 +397,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
         # waitingCreate.
         elif event.mask == pyinotify.IN_MODIFY:
             self.log.info(
-                'Modified file event of type %s at: %s', maskname, name)
+                'Modified file event of type %s at: %s' % (maskname, name))
             if name not in self.waitingCreates:
                 if "Modification" in self.et:
                     el.append((name, monitors.EventType.Modify))
@@ -413,7 +408,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
         elif (event.mask == pyinotify.IN_MOVED_FROM
                 or event.mask == pyinotify.IN_DELETE):
             self.log.info(
-                'Deleted file event of type %s at: %s', maskname, name)
+                'Deleted file event of type %s at: %s' % (maskname, name))
             if "Deletion" in self.et:
                 el.append((name, monitors.EventType.Delete))
             else:
@@ -422,43 +417,43 @@ class ProcessEvent(pyinotify.ProcessEvent):
         # These are all the currently ignored events.
         elif event.mask == pyinotify.IN_ATTRIB:
             # File attributes have changed? Useful?
-            self.log.debug('Ignored event of type %s at: %s', maskname, name)
+            self.log.debug('Ignored event of type %s at: %s' % (maskname, name))
         elif (event.mask == pyinotify.IN_DELETE_SELF
                 or event.mask == pyinotify.IN_IGNORED):
             # This is when a directory being watched is removed, handled above.
-            self.log.debug('Ignored event of type %s at: %s', maskname, name)
+            self.log.debug('Ignored event of type %s at: %s' % (maskname, name))
         elif event.mask == pyinotify.IN_MOVE_SELF:
             # This is when a directory being watched is moved out of the watch
             # area (itself!), handled above.
-            self.log.debug('Ignored event of type %s at: %s', maskname, name)
+            self.log.debug('Ignored event of type %s at: %s' % (maskname, name))
         elif event.mask == pyinotify.IN_OPEN | pyinotify.IN_ISDIR:
             # Event, dir open, we can ignore for now to reduce the log volume
             # at any rate.
-            self.log.debug('Ignored event of type %s at: %s', maskname, name)
+            self.log.debug('Ignored event of type %s at: %s' % (maskname, name))
         elif event.mask == pyinotify.IN_CLOSE_NOWRITE | pyinotify.IN_ISDIR:
             # Event, dir close, we can ignore for now to reduce the log volume
             # at any rate.
-            self.log.debug('Ignored event of type %s at: %s', maskname, name)
+            self.log.debug('Ignored event of type %s at: %s' % (maskname, name))
         elif event.mask == pyinotify.IN_ACCESS | pyinotify.IN_ISDIR:
             # Event, dir access, we can ignore for now to reduce the log volume
             # at any rate.
-            self.log.debug('Ignored event of type %s at: %s', maskname, name)
+            self.log.debug('Ignored event of type %s at: %s' % (maskname, name))
         elif event.mask == pyinotify.IN_OPEN:
             # Event, file open, we can ignore for now to reduce the log volume
             # at any rate.
-            self.log.debug('Ignored event of type %s at: %s', maskname, name)
+            self.log.debug('Ignored event of type %s at: %s' % (maskname, name))
         elif event.mask == pyinotify.IN_CLOSE_NOWRITE:
             # Event, file close, we can ignore for now to reduce the log volume
             # at any rate.
-            self.log.debug('Ignored event of type %s at: %s', maskname, name)
+            self.log.debug('Ignored event of type %s at: %s' % (maskname, name))
         elif event.mask == pyinotify.IN_ACCESS:
             # Event, file access, we can ignore for now to reduce the log
             # volume at any rate.
-            self.log.debug('Ignored event of type %s at: %s', maskname, name)
+            self.log.debug('Ignored event of type %s at: %s' % (maskname, name))
 
         # Other events, log them since they really should be caught above
         else:
-            self.log.info('Uncaught event of type %s at: %s', maskname, name)
+            self.log.info('Uncaught event of type %s at: %s' % (maskname, name))
             self.log.info('Not propagated.')
 
         if len(el) > 0:

--- a/src/fsPyinotifyMonitor.py
+++ b/src/fsPyinotifyMonitor.py
@@ -16,12 +16,14 @@ import logging
 import copy
 import time
 
-__import__("omero.all")
+__import__("omero.all")  # noqa
 import omero.grid.monitors as monitors
 from fsAbstractPlatformMonitor import AbstractPlatformMonitor
 
-importlog = logging.getLogger("fsserver." + __name__)
 from omero_ext import pyinotify
+
+
+importlog = logging.getLogger("fsserver." + __name__)
 importlog.info("Imported pyinotify version %s", str(pyinotify.__version__))
 
 # Third party path package. It provides much of the

--- a/src/fsPyinotifyMonitor.py
+++ b/src/fsPyinotifyMonitor.py
@@ -16,6 +16,14 @@ import logging
 import copy
 import time
 
+__import__("omero.all")
+import omero.grid.monitors as monitors
+from fsAbstractPlatformMonitor import AbstractPlatformMonitor
+
+importlog = logging.getLogger("fsserver." + __name__)
+from omero_ext import pyinotify
+importlog.info("Imported pyinotify version %s", str(pyinotify.__version__))
+
 # Third party path package. It provides much of the
 # functionality of os.path but without the complexity.
 # Imported as pathModule to avoid potential clashes.
@@ -24,14 +32,6 @@ try:
 except ImportError:
     # Python 2
     import path as pathModule
-
-__import__("omero.all")
-import omero.grid.monitors as monitors
-from fsAbstractPlatformMonitor import AbstractPlatformMonitor
-
-importlog = logging.getLogger("fsserver." + __name__)
-from omero_ext import pyinotify
-importlog.info("Imported pyinotify version %s", str(pyinotify.__version__))
 
 
 class PlatformMonitor(AbstractPlatformMonitor):
@@ -103,7 +103,7 @@ class PlatformMonitor(AbstractPlatformMonitor):
                 auto_add=follow)
             self.log.info('Monitor set-up on %s', str(self.pathsToMonitor))
             self.log.info('Monitoring %s events', str(self.eTypes))
-        except:
+        except Exception:
             self.log.error('Monitor failed on: %s', str(self.pathsToMonitor))
 
     def start(self):
@@ -253,9 +253,10 @@ class ProcessEvent(pyinotify.ProcessEvent):
             # pyinotify 0.8
             name = event.pathname
             maskname = event.maskname
-        except:
+        except Exception:
             # pyinotify 0.7 or below
-            name = old_div(pathModule.path(event.path), pathModule.path(event.name))
+            name = old_div(pathModule.path(event.path),
+                           pathModule.path(event.name))
             maskname = event.event_name
 
         el = []
@@ -478,8 +479,8 @@ if __name__ == "__main__":
     m = PlatformMonitor(
         [monitors.WatchEventType.Creation,
          monitors.WatchEventType.Modification],
-        monitors.PathMode.Follow, "\OMERO\DropBox", [], [], True, True, p)
+        monitors.PathMode.Follow, r"\OMERO\DropBox", [], [], True, True, p)
     try:
         m.start()
-    except:
+    except Exception:
         m.stop()

--- a/src/fsPyinotifyMonitor.py
+++ b/src/fsPyinotifyMonitor.py
@@ -8,6 +8,7 @@
 
 """
 from __future__ import division
+from future.utils import bytes_to_native_str
 from builtins import str
 from past.utils import old_div
 from builtins import object
@@ -270,6 +271,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
 
         # New directory within watch area,
         # either created, moved in or modfied attributes, ie now readable.
+        path_name = pathModule.path(bytes_to_native_str(name))
         if (event.mask == (pyinotify.IN_CREATE | pyinotify.IN_ISDIR)
                 or event.mask == (pyinotify.IN_MOVED_TO | pyinotify.IN_ISDIR)
                 or event.mask == (pyinotify.IN_ATTRIB | pyinotify.IN_ISDIR)):
@@ -283,15 +285,14 @@ class ProcessEvent(pyinotify.ProcessEvent):
                         self.log.info('Not propagated.')
                     # Handle the recursion plus create any potentially missed
                     # Create events
-                    if self.wm.watchParams[
-                            pathModule.path(name).parent].getAutoAdd():
+                    if self.wm.watchParams[path_name.parent].getAutoAdd():
                         self.wm.addWatch(
                             name, self.wm.watchParams[
-                                pathModule.path(name).parent].getMask())
+                                path_name.parent].getMask())
                         if self.wm.isPathWatched(name):
                             if self.wm.watchParams[
-                                    pathModule.path(name).parent].getRec():
-                                for d in pathModule.path(name).walkdirs(
+                                    path_name.parent].getRec():
+                                for d in path_name.walkdirs(
                                         errors='warn'):
                                     self.log.info(
                                         ('NON-INOTIFY event: '
@@ -305,9 +306,8 @@ class ProcessEvent(pyinotify.ProcessEvent):
                                         self.log.info('Not propagated.')
                                     self.wm.addWatch(
                                         str(d), self.wm.watchParams[
-                                            pathModule.path(
-                                                name).parent].getMask())
-                                for f in pathModule.path(name).walkfiles(
+                                            path_name.parent].getMask())
+                                for f in path_name.walkfiles(
                                         errors='warn'):
                                     self.log.info(
                                         'NON-INOTIFY event: New file at: %s',
@@ -315,7 +315,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
                                     el.append(
                                         (str(f), monitors.EventType.Create))
                             else:
-                                for d in pathModule.path(name).dirs():
+                                for d in path_name.dirs():
                                     self.log.info(
                                         ('NON-INOTIFY event: '
                                          'New directory at: %s'),
@@ -326,7 +326,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
                                             monitors.EventType.Create))
                                     else:
                                         self.log.info('Not propagated.')
-                                for f in pathModule.path(name).files():
+                                for f in path_name.files():
                                     self.log.info(
                                         'NON-INOTIFY event: New file at: %s',
                                         str(f))

--- a/src/fsPyinotifyMonitor.py
+++ b/src/fsPyinotifyMonitor.py
@@ -8,7 +8,7 @@
 
 """
 from __future__ import division
-from future.utils import bytes_to_native_str
+from future.utils import bytes_to_native_str, isbytes
 from builtins import str
 from past.utils import old_div
 from builtins import object
@@ -173,13 +173,17 @@ class MyWatchManager(pyinotify.WatchManager):
     def addWatch(self, path, mask):
         if not self.isPathWatched(path):
             try:
+                if isbytes(path):
+                    path_obj = pathModule.path(bytes_to_native_str(path))
+                else:
+                    path_obj = pathModule.path(path)
                 res = pyinotify.WatchManager.add_watch(
                     self, path, mask, rec=False, auto_add=False, quiet=False)
                 self.watchPaths.update(res)
                 self.watchParams[path] = copy.copy(
-                    self.watchParams[pathModule.path(path).parent])
+                    self.watchParams[path_obj.parent])
                 if self.watchParams[path].getRec():
-                    for d in pathModule.path(path).dirs():
+                    for d in path_obj.dirs():
                         self.addWatch(str(d), mask)
                 if self.isPathWatched(path):
                     self.log.info('Watch added on: %s', path)

--- a/src/fsPyinotifyMonitor.py
+++ b/src/fsPyinotifyMonitor.py
@@ -19,6 +19,7 @@ import time
 __import__("omero.all")  # noqa
 import omero.grid.monitors as monitors
 from fsAbstractPlatformMonitor import AbstractPlatformMonitor
+from fsUtil import NativeKeyDict
 
 from omero_ext import pyinotify
 
@@ -149,8 +150,8 @@ class MyWatchManager(pyinotify.WatchManager):
        may need to be fixed for applications outside of DropBox.
 
     """
-    watchPaths = {}
-    watchParams = {}
+    watchPaths = NativeKeyDict()
+    watchParams = NativeKeyDict()
     log = logging.getLogger("fsserver." + __name__)
 
     def isPathWatched(self, pathString):

--- a/src/fsUtil.py
+++ b/src/fsUtil.py
@@ -9,6 +9,21 @@
 """
 
 import logging
+from future.utils import isbytes, bytes_to_native_str
+
+
+class NativeKeyDict(dict):
+
+    def __getitem__(self, key):
+        if isbytes(key):
+            key = bytes_to_native_str(key)
+        return dict.__getitem__(self, key)
+
+    def __setitem__(self, key, val):
+        if isbytes(key):
+            key = bytes_to_native_str(key)
+        return dict.__setitem__(self, key, val)
+
 
 
 def monitorPackage(platformCheck):


### PR DESCRIPTION
Runs after the first failed to register since an exception had been thrown. This corrects the problem (`path(bytes_name)` throws) but does not deal with the deeper issue that the service should be more fault tolerant. Fixes include:

 - `NativeKeyDict` which maps stores all elements under `str` keys (even if `bytes`)
 - Log all messages via `format % (values)` rather than `log(fmt, *values)`

close #12