### PR TITLE
fsDropBoxMonitorClient: fix file cleanup (see #14)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
       pip install dist/omero-dropbox*gz
       omero version
     elif [ "$TOX" = "infra" ]; then
-        echo DISABLED: .omero/docker scripts
+        .omero/docker scripts
     else
       tox -e $TOX
     fi

--- a/src/fsDropBoxMonitorClient.py
+++ b/src/fsDropBoxMonitorClient.py
@@ -624,6 +624,8 @@ class MonitorClientI(monitors.MonitorClient):
             throwing an exception if necessary.
         """
 
+        t = None
+        to = None
         try:
             self.state.appropriateWait(self.throttleImport)  # See ticket:5739
 
@@ -681,8 +683,12 @@ class MonitorClientI(monitors.MonitorClient):
                     self.log.error("%s not found !" % t)
                 self.log.error("***** end of output from importer-cli *****")
         finally:
-            remove_path(t)
-            remove_path(to)
+            for x in (t, to):
+                if x:
+                    try:
+                        remove_path(x)
+                    except Exception as e:
+                        self.log.error("failed to remove %s: %s" % (x, e))
 
         return imageId
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,6 @@ deps =
     future
     numpy
     pytest
-    pytest-sugar
-    pytest-xdist
     restructuredtext-lint
     py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
@@ -23,4 +21,4 @@ passenv =
 commands =
     rst-lint README.rst
     python setup.py install
-    pytest {posargs:-n4 -m "not broken" -rf test}
+    pytest {posargs: -m "not broken" -rf test}


### PR DESCRIPTION
If login for a user failed, the importFile method
failed since the finally blocked attempt to remove
temporary files that had not yet been created.