### PR TITLE
Review all instances of whitelist/blacklist

### DIFF
--- a/src/fsAbstractPlatformMonitor.py
+++ b/src/fsAbstractPlatformMonitor.py
@@ -21,7 +21,7 @@ class AbstractPlatformMonitor(threading.Thread):
 
     """
 
-    def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
+    def __init__(self, eventTypes, pathMode, pathString, allowlist, blocklist,
                  ignoreSysFiles, ignoreDirEvents, proxy):
         """
             Set-up Monitor thread.
@@ -34,8 +34,8 @@ class AbstractPlatformMonitor(threading.Thread):
 
         self.pathMode = str(pathMode)
         self.pathsToMonitor = pathString
-        self.whitelist = whitelist
-        self.blacklist = blacklist
+        self.allowlist = allowlist
+        self.blocklist = blocklist
         self.ignoreSysFiles = ignoreSysFiles
         self.ignoreDirEvents = ignoreDirEvents
         self.proxy = proxy

--- a/src/fsDirectory.py
+++ b/src/fsDirectory.py
@@ -35,8 +35,8 @@ class Directory(object):
         the file system.
 
         :group Constructor: __init__
-        :group Accessors: getPath, getWhitelist, getBlacklist
-        :group Query Methods: onWhitelist, onBlacklist, isSubdirectory
+        :group Accessors: getPath, getAllowlist, getBlocklist
+        :group Query Methods: onAllowlist, onBlocklist, isSubdirectory
         :group Tree manipulation: patchTree
         :group Tree comparison: getExtraFilesFromTree, getChangedFilesFromTree
         :group Other Methods: getFile, pruneZeroFiles, getChangedFiles
@@ -44,7 +44,7 @@ class Directory(object):
 
     """
 
-    def __init__(self, pathString, whitelist=None, pathMode='Flat'):
+    def __init__(self, pathString, allowlist=None, pathMode='Flat'):
         """
             Build a tree of the directory given its path.
 
@@ -54,9 +54,9 @@ class Directory(object):
             :Parameters:
                 pathString : string
                     A full path to the directory of interest.
-                whitelist : Whitelist
+                allowlist : Allowlist
                     A list of extensions of interest.
-                blacklist : Blacklist
+                blocklist : Blocklist
                     A list of subdirectories to be ignored.
 
         """
@@ -67,11 +67,11 @@ class Directory(object):
         #: path as a pathModule path type
         self.path = pathModule.path(self.pathString)
 
-        # Use an empty whitelist if necessary.
-        if whitelist is None:
-            whitelist = []
-        #: whitelist of extensions
-        self.whitelist = fsLists.Whitelist(whitelist)
+        # Use an empty allowlist if necessary.
+        if allowlist is None:
+            allowlist = []
+        #: allowlist of extensions
+        self.allowlist = fsLists.Allowlist(allowlist)
 
         self.pathMode = pathMode
 
@@ -96,15 +96,15 @@ class Directory(object):
         reprStr += str(self.root)
         return reprStr
 
-    def getWhitelist(self):
+    def getAllowlist(self):
         """
-            Getter for the whitelist.
+            Getter for the allowlist.
 
-            :return: String representation whitelist.
+            :return: String representation allowlist.
             :rtype: list<string>
 
         """
-        return self.whitelist.asList()
+        return self.allowlist.asList()
 
     def getPath(self):
         """
@@ -116,19 +116,19 @@ class Directory(object):
         """
         return self.path
 
-    def onWhitelist(self, ext):
+    def onAllowlist(self, ext):
         """
-            Return true if extension is on whitelist of extensions.
+            Return true if extension is on allowlist of extensions.
 
             :Parameters:
                 ext : string
                     A file extension.
 
-            :return: Status of extension on whitelist.
+            :return: Status of extension on allowlist.
             :rtype: boolean
 
         """
-        return self.whitelist.onList(ext)
+        return self.allowlist.onList(ext)
 
     def isSubdirectory(self, pathString):
         """
@@ -137,7 +137,7 @@ class Directory(object):
 
             :todo: Check and return a value is pathString is a subdirectory
                 of the current Directory's path. This should be used when
-                first creating a snapshot to confirm that the blacklist
+                first creating a snapshot to confirm that the blocklist
                 contains valid subdirectories.
 
             :return: Status of subdirectory as part of directory.
@@ -177,7 +177,7 @@ class Directory(object):
 #         subTree = None
 #         path = pathModule.path(pathString)
 #         subPath = self.getPath().relpathto(path)
-#         if not self.onBlacklist(subPath):
+#         if not self.onBlocklist(subPath):
 #             subTree = self.root
 #             subParts = subPath.splitall()
 #             for part in subParts[1:]:
@@ -190,7 +190,7 @@ class Directory(object):
             Replace a subtree from the snaphot starting at pathString with
             new subtree.
 
-            For the given pathString, if it isn't on the blacklist,
+            For the given pathString, if it isn't on the blocklist,
             create a new tree from the live file system.
             Then, find the node in the snapshot representing the archive of
             that path.
@@ -362,7 +362,7 @@ class Directory(object):
 
             Co-ordinate the action of patching the snapshot and comparing
             files in the new and old trees. It is possible that both new
-            and old trees will be None if a blacklisted directory has been
+            and old trees will be None if a blocklisted directory has been
             the cause of an event, in this case empty lists are returned.
 
             :Parameters:
@@ -605,7 +605,7 @@ class DirNode(Node):
 
         """
         if path.isfile():
-            if self.base.onWhitelist(path.ext):
+            if self.base.onAllowlist(path.ext):
                 self.children[path.name] = FileNode(path)
         elif path.isdir():
             if self.mode == 'Flat':

--- a/src/fsDropBox.py
+++ b/src/fsDropBox.py
@@ -199,8 +199,8 @@ class DropBox(Ice.Application):
                         monitorParameters[user]['eventTypes'],
                         monitorParameters[user]['pathMode'],
                         monitorParameters[user]['watchDir'],
-                        monitorParameters[user]['whitelist'],
-                        monitorParameters[user]['blacklist'],
+                        monitorParameters[user]['allowlist'],
+                        monitorParameters[user]['blocklist'],
                         monitorParameters[user]['timeout'],
                         monitorParameters[user]['blockSize'],
                         monitorParameters[user]['ignoreSysFiles'],
@@ -416,10 +416,10 @@ class DropBox(Ice.Application):
                 "omero.fs.eventTypes", "All").split(';'))
             pathMode = list(props.getPropertyWithDefault(
                 "omero.fs.pathMode", "Follow").split(';'))
-            whitelist = list(props.getPropertyWithDefault(
-                "omero.fs.whitelist", "").split(';'))
-            blacklist = list(props.getPropertyWithDefault(
-                "omero.fs.blacklist", "").split(';'))
+            allowlist = list(props.getPropertyWithDefault(
+                "omero.fs.allowlist", "").split(';'))
+            blocklist = list(props.getPropertyWithDefault(
+                "omero.fs.blocklist", "").split(';'))
             timeout = list(props.getPropertyWithDefault(
                 "omero.fs.timeout", "0.0").split(';'))
             blockSize = list(props.getPropertyWithDefault(
@@ -471,16 +471,16 @@ class DropBox(Ice.Application):
                         monitorParams[importUser[i]][
                             'pathMode'] = monitors.PathMode.__dict__["Follow"]
 
-                    monitorParams[importUser[i]]['whitelist'] = []
-                    for white in whitelist[i].split(','):
+                    monitorParams[importUser[i]]['allowlist'] = []
+                    for white in allowlist[i].split(','):
                         if white.strip(string.whitespace):
-                            monitorParams[importUser[i]]['whitelist'].append(
+                            monitorParams[importUser[i]]['allowlist'].append(
                                 white.strip(string.whitespace))
 
-                    monitorParams[importUser[i]]['blacklist'] = []
-                    for black in blacklist[i].split(','):
+                    monitorParams[importUser[i]]['blocklist'] = []
+                    for black in blocklist[i].split(','):
                         if black.strip(string.whitespace):
-                            monitorParams[importUser[i]]['blacklist'].append(
+                            monitorParams[importUser[i]]['blocklist'].append(
                                 black.strip(string.whitespace))
 
                     try:

--- a/src/fsLists.py
+++ b/src/fsLists.py
@@ -5,7 +5,7 @@
 
     These are fairly trivial classes to wrap sets. In the present
     implementation there is no functional difference between
-    Whitelist and Blacklist. They have been factored out for literal
+    Allowlist and Blocklist. They have been factored out for literal
     reasons and to leave the door open for future changes.
 
     Copyright 2009 University of Dundee. All rights reserved.
@@ -117,10 +117,10 @@ class Greylist(object):
             return anItem in self.theSet
 
 
-class Whitelist(Greylist):
+class Allowlist(Greylist):
 
     """
-        A class representing a whitelist of file extensions
+        A class representing a allowlist of file extensions
         that should be included in any watching.
 
         :group Constructor: __init__
@@ -129,7 +129,7 @@ class Whitelist(Greylist):
 
     def __init__(self, initialList=None):
         """
-            Create an initial whitelist.
+            Create an initial allowlist.
 
             :Parameters:
                 initialList : list<string>
@@ -141,10 +141,10 @@ class Whitelist(Greylist):
         Greylist.__init__(self, initialList)
 
 
-class Blacklist(Greylist):
+class Blocklist(Greylist):
 
     """
-        A class representing a blacklist of paths that should be
+        A class representing a blocklist of paths that should be
         excluded from any watching.
 
         :group Constructor: __init__
@@ -153,7 +153,7 @@ class Blacklist(Greylist):
 
     def __init__(self, initialList=None):
         """
-            Create an initial blacklist.
+            Create an initial blocklist.
 
             :Parameters:
                 initialList : list<string>

--- a/src/fsMac-10-5-Monitor.py
+++ b/src/fsMac-10-5-Monitor.py
@@ -51,7 +51,7 @@ class PlatformMonitor(AbstractPlatformMonitor):
 
     """
 
-    def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
+    def __init__(self, eventTypes, pathMode, pathString, allowlist, blocklist,
                  ignoreSysFiles, ignoreDirEvents, proxy):
         """
             Set-up Monitor thread.
@@ -70,10 +70,10 @@ class PlatformMonitor(AbstractPlatformMonitor):
                 pathString : string
                     A string representing a path to be monitored.
 
-                whitelist : list<string>
+                allowlist : list<string>
                     A list of files and extensions of interest.
 
-                blacklist : list<string>
+                blocklist : list<string>
                     A list of subdirectories to be excluded.
 
                 ignoreSysFiles :
@@ -87,7 +87,7 @@ class PlatformMonitor(AbstractPlatformMonitor):
 
         """
         AbstractPlatformMonitor.__init__(
-            self, eventTypes, pathMode, pathString, whitelist, blacklist,
+            self, eventTypes, pathMode, pathString, allowlist, blocklist,
             ignoreSysFiles, ignoreDirEvents, proxy)
         self.log = logging.getLogger("fsserver." + __name__)
 
@@ -113,7 +113,7 @@ class PlatformMonitor(AbstractPlatformMonitor):
         pathsToMonitor.insertObject_atIndex_(ms, 0)
 
         self.directory = fsDirectory.Directory(
-            pathString=self.pathsToMonitor, whitelist=self.whitelist,
+            pathString=self.pathsToMonitor, allowlist=self.allowlist,
             pathMode=self.pathMode)
 
         self.streamRef = FSEvents.FSEventStreamCreate(

--- a/src/fsMonitor.py
+++ b/src/fsMonitor.py
@@ -19,25 +19,25 @@ import omero.grid.monitors as monitors
 class MonitorFactory(object):
 
     @staticmethod
-    def createMonitor(mType, eTypes, pMode, pathString, whitelist, blacklist,
+    def createMonitor(mType, eTypes, pMode, pathString, allowlist, blocklist,
                       timeout, blockSize, ignoreSysFiles, ignoreDirEvents,
                       platformCheck, proxy, monitorId):
 
         if str(mType) == 'Persistent':
             return PersistentMonitor(
-                eTypes, pMode, pathString, whitelist, blacklist, timeout,
+                eTypes, pMode, pathString, allowlist, blocklist, timeout,
                 blockSize, ignoreSysFiles, ignoreDirEvents, platformCheck,
                 proxy, monitorId)
 
         elif str(mType) == 'OneShot':
             return OneShotMonitor(
-                eTypes, pMode, pathString, whitelist, blacklist, timeout,
+                eTypes, pMode, pathString, allowlist, blocklist, timeout,
                 ignoreSysFiles, ignoreDirEvents, platformCheck, proxy,
                 monitorId)
 
         elif str(mType) == 'Inactivity':
             return InactivityMonitor(
-                eTypes, pMode, pathString, whitelist, blacklist, timeout,
+                eTypes, pMode, pathString, allowlist, blocklist, timeout,
                 ignoreSysFiles, ignoreDirEvents, platformCheck, proxy,
                 monitorId)
 
@@ -55,7 +55,7 @@ class AbstractMonitor(object):
 
     """
 
-    def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
+    def __init__(self, eventTypes, pathMode, pathString, allowlist, blocklist,
                  ignoreSysFiles, ignoreDirEvents, platformCheck, proxy,
                  monitorId):
         """
@@ -71,7 +71,7 @@ class AbstractMonitor(object):
         self.proxy = proxy
         self.monitorId = monitorId
         self.pMonitor = PlatformMonitor.PlatformMonitor(
-            eventTypes, pathMode, pathString, whitelist, blacklist,
+            eventTypes, pathMode, pathString, allowlist, blocklist,
             ignoreSysFiles, ignoreDirEvents, self)
 
     def start(self):
@@ -126,7 +126,7 @@ class PersistentMonitor(AbstractMonitor):
 
     """
 
-    def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
+    def __init__(self, eventTypes, pathMode, pathString, allowlist, blocklist,
                  timeout, blockSize, ignoreSysFiles, ignoreDirEvents,
                  platformCheck, proxy, monitorId):
         """
@@ -134,7 +134,7 @@ class PersistentMonitor(AbstractMonitor):
 
         """
         AbstractMonitor.__init__(
-            self, eventTypes, pathMode, pathString, whitelist, blacklist,
+            self, eventTypes, pathMode, pathString, allowlist, blocklist,
             ignoreSysFiles, ignoreDirEvents, platformCheck, proxy, monitorId)
 
         self.notifier = NotificationScheduler(
@@ -184,7 +184,7 @@ class InactivityMonitor(AbstractMonitor):
 
     """
 
-    def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
+    def __init__(self, eventTypes, pathMode, pathString, allowlist, blocklist,
                  timeout, ignoreSysFiles, ignoreDirEvents, platformCheck,
                  proxy, monitorId):
         """
@@ -192,7 +192,7 @@ class InactivityMonitor(AbstractMonitor):
 
         """
         AbstractMonitor.__init__(
-            self, eventTypes, pathMode, pathString, whitelist, blacklist,
+            self, eventTypes, pathMode, pathString, allowlist, blocklist,
             ignoreSysFiles, ignoreDirEvents, platformCheck, proxy, monitorId)
         self.timer = threading.Timer(timeout, self.inactive)
         self.log.info('Inactivity monitor created. Timer: %s', str(self.timer))
@@ -258,7 +258,7 @@ class OneShotMonitor(AbstractMonitor):
 
     """
 
-    def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
+    def __init__(self, eventTypes, pathMode, pathString, allowlist, blocklist,
                  timeout, ignoreSysFiles, ignoreDirEvents, platformCheck,
                  proxy, monitorId):
         """
@@ -266,7 +266,7 @@ class OneShotMonitor(AbstractMonitor):
 
         """
         AbstractMonitor.__init__(
-            self, eventTypes, pathMode, pathString, whitelist, blacklist,
+            self, eventTypes, pathMode, pathString, allowlist, blocklist,
             ignoreSysFiles, ignoreDirEvents, platformCheck, proxy, monitorId)
         self.timer = threading.Timer(timeout, self.inactive)
         self.log.info('OneShot monitor created. Timer: %s', str(self.timer))

--- a/src/fsMonitorServer.py
+++ b/src/fsMonitorServer.py
@@ -53,8 +53,8 @@ class MonitorServerI(monitors.MonitorServer):
 
     """
 
-    def createMonitor(self, mType, eTypes, pMode, pathString, whitelist,
-                      blacklist, timeout, blockSize, ignoreSysFiles,
+    def createMonitor(self, mType, eTypes, pMode, pathString, allowlist,
+                      blocklist, timeout, blockSize, ignoreSysFiles,
                       ignoreDirEvents, platformCheck, proxy, current=None):
         """
             Create a the Monitor for a given path.
@@ -73,10 +73,10 @@ class MonitorServerI(monitors.MonitorServer):
                 pathString : string
                     A string representing a path to be monitored.
 
-                whitelist : list<string>
+                allowlist : list<string>
                     A list of extensions of interest.
 
-                blacklist : list<string>
+                blocklist : list<string>
                     A list of subdirectories to be excluded.
 
                 timeout : float
@@ -112,7 +112,7 @@ class MonitorServerI(monitors.MonitorServer):
             # blockSize (0) and ignoreDirEvents (True) hardwired until slice is
             # changed.
             self.monitors[monitorId] = MonitorFactory.createMonitor(
-                mType, eTypes, pMode, pathString, whitelist, blacklist,
+                mType, eTypes, pMode, pathString, allowlist, blocklist,
                 timeout, blockSize, ignoreSysFiles, ignoreDirEvents,
                 platformCheck, self, monitorId)
 

--- a/src/fsPyinotifyMonitor.py
+++ b/src/fsPyinotifyMonitor.py
@@ -47,7 +47,7 @@ class PlatformMonitor(AbstractPlatformMonitor):
 
     """
 
-    def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
+    def __init__(self, eventTypes, pathMode, pathString, allowlist, blocklist,
                  ignoreSysFiles, ignoreDirEvents, proxy):
         """
             Set-up Monitor thread.
@@ -66,10 +66,10 @@ class PlatformMonitor(AbstractPlatformMonitor):
                 pathString : string
                     A string representing a path to be monitored.
 
-                whitelist : list<string>
+                allowlist : list<string>
                     A list of files and extensions of interest.
 
-                blacklist : list<string>
+                blocklist : list<string>
                     A list of subdirectories to be excluded.
 
                 ignoreSysFiles :
@@ -83,7 +83,7 @@ class PlatformMonitor(AbstractPlatformMonitor):
 
         """
         AbstractPlatformMonitor.__init__(
-            self, eventTypes, pathMode, pathString, whitelist, blacklist,
+            self, eventTypes, pathMode, pathString, allowlist, blocklist,
             ignoreSysFiles, ignoreDirEvents, proxy)
         self.log = logging.getLogger("fsserver." + __name__)
 

--- a/src/fsWin-XP-Monitor.py
+++ b/src/fsWin-XP-Monitor.py
@@ -41,7 +41,7 @@ class PlatformMonitor(AbstractPlatformMonitor):
 
     """
 
-    def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
+    def __init__(self, eventTypes, pathMode, pathString, allowlist, blocklist,
                  ignoreSysFiles, ignoreDirEvents, proxy):
         """
             Set-up Monitor thread.
@@ -60,10 +60,10 @@ class PlatformMonitor(AbstractPlatformMonitor):
                 pathString : string
                     A string representing a path to be monitored.
 
-                whitelist : list<string>
+                allowlist : list<string>
                     A list of files and extensions of interest.
 
-                blacklist : list<string>
+                blocklist : list<string>
                     A list of subdirectories to be excluded.
 
                 ignoreSysFiles :
@@ -76,7 +76,7 @@ class PlatformMonitor(AbstractPlatformMonitor):
                     A proxy to be informed of events
         """
         AbstractPlatformMonitor.__init__(
-            self, eventTypes, pathMode, pathString, whitelist, blacklist,
+            self, eventTypes, pathMode, pathString, allowlist, blocklist,
             ignoreSysFiles, ignoreDirEvents, proxy)
         self.log = logging.getLogger("fsserver." + __name__)
 
@@ -168,9 +168,9 @@ class PlatformMonitor(AbstractPlatformMonitor):
                                     eventType = self.actions[action]
                                     # Should have richer filename matching
                                     # here.
-                                    if (len(self.whitelist) == 0
+                                    if (len(self.allowlist) == 0
                                             or pathModule.path(filename).ext
-                                            in self.whitelist):
+                                            in self.allowlist):
                                         eventList.append(
                                             (filename.replace(
                                                 '\\\\', '\\').replace(
@@ -189,9 +189,9 @@ class PlatformMonitor(AbstractPlatformMonitor):
                                     eventType = self.actions[action]
                                     # Should have richer filename matching
                                     # here.
-                                    if (len(self.whitelist) == 0
+                                    if (len(self.allowlist) == 0
                                             or pathModule.path(filename).ext
-                                            in self.whitelist):
+                                            in self.allowlist):
                                         eventList.append(
                                             (filename.replace(
                                                 '\\\\', '\\').replace(
@@ -210,9 +210,9 @@ class PlatformMonitor(AbstractPlatformMonitor):
                                     eventType = self.actions[action]
                                     # Should have richer filename matching
                                     # here.
-                                    if (len(self.whitelist) == 0
+                                    if (len(self.allowlist) == 0
                                             or pathModule.path(filename).ext
-                                            in self.whitelist):
+                                            in self.allowlist):
                                         eventList.append(
                                             (filename.replace(
                                                 '\\\\', '\\').replace(


### PR DESCRIPTION
This does _not_ try to maintain backwards compatibility
since the related methods and classes are internal. The
likeliest impact is that of the change in property name.
A redirecting property could be added here, but a nicer
choice is likely to automatically upgrade in omero-py.

see: https://github.com/ome/bioformats/issues/3580