### PR TITLE
switch to new output command

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -29,6 +29,6 @@ jobs:
         id: toxtarget
         run: |
           py=$(echo ${{ matrix.python-version }} | tr -d .)
-          echo "::set-output name=py::$py"
+          echo "py=$py" >> $GITHUB_OUTPUT
       - name: Run tests
         run: tox -e py${{ steps.toxtarget.outputs.py }}


### PR DESCRIPTION
Check that the build is green
Background https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 