### PR TITLE
Add Python 3.11 to the testing matrix

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,6 +16,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.omeroci/scripts-copy
+++ b/.omeroci/scripts-copy
@@ -7,4 +7,3 @@ set -x
 
 cd $TARGET
 echo No-op: scripts could potentially be renamed to "core" or "internal"
-/opt/omero/server/venv3/bin/pip install mox3

--- a/setup.py
+++ b/setup.py
@@ -55,4 +55,4 @@ setup(name="omero-dropbox",
           "omero-py",  # requires Ice (use wheel for faster installs)
       ],
       python_requires='>=3',
-      tests_require=['pytest'])
+      tests_require=['pytest', 'pytest-mock'])

--- a/test/drivers.py
+++ b/test/drivers.py
@@ -29,7 +29,6 @@ except ImportError:
     # Python 2
     from path import path
 from omero.util import ServerContext
-from mox3 import mox
 from functools import wraps
 from omero.util.temp_files import create_path
 from fsDropBoxMonitorClient import MonitorClientI
@@ -352,14 +351,9 @@ class mock_communicator(object):
 class MockServerContext(ServerContext):
 
     def __init__(self, ic, get_root):
-        self.mox = mox.Mox()
         self.communicator = ic
         self.getSession = get_root
         self.stop_event = threading.Event()
-
-    def newSession(self, *args):
-        sess = self.mox.CreateMock(omero.api.ServiceFactoryPrx.__class__)
-        return sess
 
 
 class MockMonitor(MonitorClientI):
@@ -381,9 +375,10 @@ class MockMonitor(MonitorClientI):
             post = []
         self.root = None
         ic = mock_communicator()
+        self.ctx = MockServerContext(ic, self.get_root)
         MonitorClientI.__init__(
             self, dir, ic, getUsedFiles=self.used_files,
-            ctx=MockServerContext(ic, self.get_root), worker_wait=0.1)
+            ctx=self.ctx, worker_wait=0.1)
         self.log = logging.getLogger("MockMonitor")
         self.events = []
         self.files = {}

--- a/test/unit/test_monitor.py
+++ b/test/unit/test_monitor.py
@@ -41,17 +41,17 @@ class TestMonitor(object):
     def testEmptyAdd(self):
         MockMonitor().fsEventHappened('', [])  # Does nothing.
 
-    @pytest.mark.broken(ticket="12566")
     @with_driver
-    def testBasicAdd(self):
+    def testBasicAdd(self, mocker):
+        mocker.patch.object(self.client.ctx,'newSession', autospec=True)
         self.driver.add(DirInfoEvent(1, monitors.EventInfo(
             self.dir / "root" / "dirtimeout",
             monitors.EventType.Create)))
         self.driver.run()
 
-    @pytest.mark.broken(ticket="12566")
     @with_driver
-    def testWithSingleImport(self):
+    def testWithSingleImport(self, mocker):
+        mocker.patch.object(self.client.ctx,'newSession', autospec=True)
         f = self.dir / "root" / "file"
         self.client.files = {str(f): [str(f)]}
         self.driver.add(DirInfoEvent(0, monitors.EventInfo(
@@ -59,9 +59,9 @@ class TestMonitor(object):
         self.driver.run()
         time.sleep(0.25)
 
-    @pytest.mark.broken(ticket="12566")
     @with_driver
-    def testWithMultiImport(self):
+    def testWithMultiImport(self, mocker):
+        mocker.patch.object(self.client.ctx,'newSession', autospec=True)
         f1 = str(self.dir / "root" / "file1")
         f2 = str(self.dir / "root" / "file2")
         f3 = str(self.dir / "root" / "file3")
@@ -79,9 +79,9 @@ class TestMonitor(object):
         time.sleep(1)
         self.driver.run()
 
-    @pytest.mark.broken(ticket="12566")
     @with_driver
-    def testDirectoryInDirectory(self):
+    def testDirectoryInDirectory(self, mocker):
+        mocker.patch.object(self.client.ctx,'newSession', autospec=True)
         self.driver.add(DirInfoEvent(1, monitors.EventInfo(
             self.dir / "root" / "dir", monitors.EventType.Create)))
         self.driver.add(DirInfoEvent(1, monitors.EventInfo(

--- a/test/unit/test_state.py
+++ b/test/unit/test_state.py
@@ -44,28 +44,24 @@ def clearcb(log, state, key):
 class TestState(object):
 
     def setup_method(self, method):
-        self.s = fsDBMC.MonitorState()
+        self.s = fsDBMC.MonitorState(None)
         self.log = logging.getLogger(make_logname(self))
 
     def teardown_method(self, method):
         self.s.stop()
 
-    @pytest.mark.broken(ticket="12566")
     def testEmpty(self):
         self.s.update({}, 0, nullcb)
 
-    @pytest.mark.broken(ticket="12566")
     def testSimple(self):
         self.s.update({'file1': ['file1', 'file2']}, 0, nullcb)
 
-    @pytest.mark.broken(ticket="12566")
     def testTimerCalled(self):
         l = []
         self.s.update({'file1': ['file1', 'file2']}, 0, listcb(l))
         time.sleep(0.25)
         assert 1 == len(l)
 
-    @pytest.mark.broken(ticket="12566")
     def testMultipleInsert(self):
         l = []
         m = {
@@ -77,7 +73,6 @@ class TestState(object):
         time.sleep(0.25)
         assert 1 == len(l)
 
-    @pytest.mark.broken(ticket="12566")
     def testAddThenReAdd(self):
         l = []
         self.s.update({'file1': ['file1', 'file2']}, 0.1, listcb(l))
@@ -85,7 +80,6 @@ class TestState(object):
         time.sleep(0.25)
         assert 1 == len(l)
 
-    @pytest.mark.broken(ticket="12566")
     def testAddThenModify(self):
         l = []
         self.s.update({'file1': ['file1', 'file2']}, 0.1, listcb(l))
@@ -93,17 +87,15 @@ class TestState(object):
         time.sleep(0.25)
         assert 1 == len(l)
 
-    @pytest.mark.broken(ticket="12566")
     def testEntryMoved1(self):
         l = []
         self.s.update({'file1': ['file1']}, 0.1, listcb(l))
-        assert 1 == list(self.s.keys())
+        assert 1 == len(list(self.s.keys()))
         self.s.update({'file2': ['file1', 'file2']}, 0.1, listcb(l))
-        assert 2 == list(self.s.keys())
+        assert 2 == len(list(self.s.keys()))
         time.sleep(0.25)
         assert 1 == len(l)
 
-    @pytest.mark.broken(ticket="12566")
     def testEntryMoved2(self):
         self.s.update(
             {'file1': ['file1']}, 0.1, clearcb(self.log, self.s, 'file1'))
@@ -118,7 +110,6 @@ class TestState(object):
         assert 0 == len(list(self.s.keys()))
         assert 0 == self.s.count()
 
-    @pytest.mark.broken(ticket="12566")
     def testEntryOutOfSyncSubsume(self):
         self.s.update({'file1': ['file1']}, 0.1, nullcb)
         assert 1 == len(list(self.s.keys()))
@@ -127,7 +118,6 @@ class TestState(object):
         self.s.update({'file2': ['file1', 'file2']}, 0.1, nullcb)
         assert 2 == len(list(self.s.keys()))
 
-    @pytest.mark.broken(ticket="12566")
     def testEntryOutOfSyncSteal(self):
         self.s.update({'file1': ['file1', 'file3']}, 0.1, nullcb)
         assert 2 == len(list(self.s.keys()))

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,12 @@ deps =
     future
     numpy
     pytest
+    pytest-mock
     restructuredtext-lint
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
     https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231024/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; platform_system=="Linux" and python_version=="3.11"
-    mox3
 setenv =
     ICE_CONFIG = {toxinidir}/ice.config
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
+    https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231024/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; platform_system=="Linux" and python_version=="3.11"
     mox3
 setenv =
     ICE_CONFIG = {toxinidir}/ice.config


### PR DESCRIPTION
Companion to https://github.com/ome/omero-py/pull/385, this PR makes the minimal set of adjustements to test `omero-dropbox` on Python 3.11.

The `mox3` library is removed in favor of the standard library `mock` module and installed via `pytest-mock`. As a bonus, most of the unit tests currently marked as broken as reactivated and should be passing on Python 3.8-3.11.

While the changes do not strictly depend on  https://github.com/ome/omero-py/pull/385, both PRs will need to be deployed together in order to functionally test an OMERO.server with Dropbox in a Python 3.11 environment.